### PR TITLE
Change to use ctrl.ctrl->page instead of ctrl.ns.lba_data_size

### DIFF
--- a/include/page_cache.h
+++ b/include/page_cache.h
@@ -770,7 +770,7 @@ struct page_cache_t {
         std::cout << "pages_dma: " << std::hex << this->pages_dma.get()->vaddr << "\t" << this->pages_dma.get()->ioaddrs[0] << std::endl;
         std::cout << "HEREN\n";
         const uint32_t uints_per_page = ctrl.ctrl->page_size / sizeof(uint64_t);
-        if ((pdt.page_size > (ctrl.ns.lba_data_size * uints_per_page)) || (np == 0) || (pdt.page_size < ctrl.ns.lba_data_size))
+        if ((pdt.page_size > (ctrl.ctrl->page_size * uints_per_page)) || (np == 0) || (pdt.page_size < ctrl.ns.lba_data_size))
             throw error(string("page_cache_t: Can't have such page size or number of pages"));
         if (ps <= this->pages_dma.get()->page_size) {
             std::cout << "Cond1\n";


### PR DESCRIPTION
In line 773 of include/page_cache.h, we changed to use ctrl.ctrl->page instead of ctrl.ns.lba_data_size to calculate the maximum transfer size of a command